### PR TITLE
feat: merge limit counts in one row

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,12 +1,12 @@
 DATABASE_URL=postgresql://app:app@localhost:5432/app
 DATABASE_ASYNC_URL=postgresql+asyncpg://app:app@localhost:5432/app
 
+ENV=local
+
 ENVIRONMENT=LOCAL
 
 CORS_HEADERS=["*"]
 CORS_ORIGINS=["http://localhost:3000"]
-
-
 
 DB_HOST='localhost'
 DB_NAME='app'

--- a/alembic/versions/2025-02-04_merge_limits_count.py
+++ b/alembic/versions/2025-02-04_merge_limits_count.py
@@ -1,0 +1,75 @@
+"""merge_limits_count
+
+Revision ID: 6f7a38a03aab
+Revises: 4bf5f870ba86
+Create Date: 2025-02-04 21:12:05.506320
+
+"""
+
+from typing import Sequence
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '6f7a38a03aab'
+down_revision: str | None = '4bf5f870ba86'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column('user_subscriptions', sa.Column('generation_photos_left', sa.Integer(), nullable=False, server_default='0'))
+
+    # Заполняем новое поле суммой старых значений
+    op.execute("""
+        UPDATE user_subscriptions
+        SET generation_photos_left = photos_by_prompt_left + photos_by_image_left;
+    """)
+
+    # Удаляем старые поля
+    op.drop_column('user_subscriptions', 'photos_by_prompt_left')
+    op.drop_column('user_subscriptions', 'photos_by_image_left')
+
+    # Добавляем новое поле в subscriptions_details
+    op.add_column('subscriptions_details', sa.Column('generation_photos_count', sa.Integer(), nullable=False, server_default='0'))
+
+    # Заполняем новое поле суммой старых значений
+    op.execute("""
+        UPDATE subscriptions_details
+        SET generation_photos_count = photos_by_prompt_count + photos_by_image_count;
+    """)
+
+    # Удаляем старые поля
+    op.drop_column('subscriptions_details', 'photos_by_prompt_count')
+    op.drop_column('subscriptions_details', 'photos_by_image_count')
+    pass
+
+
+def downgrade() -> None:
+    op.add_column('user_subscriptions', sa.Column('photos_by_prompt_left', sa.Integer(), nullable=False, server_default='0'))
+    op.add_column('user_subscriptions', sa.Column('photos_by_image_left', sa.Integer(), nullable=False, server_default='0'))
+
+    # Восстанавливаем данные, разделяя на два поля (делим поровну, при необходимости можно скорректировать логику)
+    op.execute("""
+        UPDATE user_subscriptions
+        SET photos_by_prompt_left = generation_photos_left / 2,
+            photos_by_image_left = generation_photos_left / 2;
+    """)
+
+    # Удаляем новое поле
+    op.drop_column('user_subscriptions', 'generation_photos_left')
+
+    # Добавляем старые поля обратно в subscriptions_details
+    op.add_column('subscriptions_details', sa.Column('photos_by_prompt_count', sa.Integer(), nullable=False, server_default='0'))
+    op.add_column('subscriptions_details', sa.Column('photos_by_image_count', sa.Integer(), nullable=False, server_default='0'))
+
+    # Восстанавливаем данные, разделяя на два поля
+    op.execute("""
+        UPDATE subscriptions_details
+        SET photos_by_prompt_count = generation_photos_count / 2,
+            photos_by_image_count = generation_photos_count / 2;
+    """)
+
+    # Удаляем новое поле
+    op.drop_column('subscriptions_details', 'generation_photos_count')
+    pass

--- a/poetry.lock
+++ b/poetry.lock
@@ -504,14 +504,14 @@ dev = ["Sphinx (==8.1.3)", "build (==1.2.2)", "colorama (==0.4.5)", "colorama (=
 
 [[package]]
 name = "mako"
-version = "1.3.8"
+version = "1.3.9"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "Mako-1.3.8-py3-none-any.whl", hash = "sha256:42f48953c7eb91332040ff567eb7eea69b22e7a4affbc5ba8e845e8f730f6627"},
-    {file = "mako-1.3.8.tar.gz", hash = "sha256:577b97e414580d3e088d47c2dbbe9594aa7a5146ed2875d4dfa9075af2dd3cc8"},
+    {file = "Mako-1.3.9-py3-none-any.whl", hash = "sha256:95920acccb578427a9aa38e37a186b1e43156c87260d7ba18ca63aa4c7cbd3a1"},
+    {file = "mako-1.3.9.tar.gz", hash = "sha256:b5d65ff3462870feec922dbccf38f6efb44e5714d7b593a656be86663d8600ac"},
 ]
 
 [package.dependencies]
@@ -1253,7 +1253,7 @@ files = [
 
 [package.dependencies]
 greenlet = [
-    {version = "!=0.4.17", optional = true, markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") or extra == \"asyncio\""},
+    {version = "!=0.4.17", markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"},
     {version = "!=0.4.17", optional = true, markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") or extra == \"asyncio\""},
 ]
 typing-extensions = ">=4.6.0"

--- a/sql_scripts/populate_subscriptions.sql
+++ b/sql_scripts/populate_subscriptions.sql
@@ -1,18 +1,18 @@
 INSERT INTO subscriptions_details (
     subscription_name, subscription_type, cost_rubles, cost_stars, duration,
-    is_active, models_count, photos_by_prompt_count, photos_by_image_count
+    is_active, models_count, generation_photos_count, photos_by_image_count
 ) VALUES
-    ('monthly_small',            'monthly',       900,   375,   30,     TRUE, 1, 50,  50),
-    ('monthly_middle',           'monthly',       1200,  495,  30,     TRUE, 1, 150, 150),
-    ('monthly_large',            'monthly',       5300,  2200,  30,     TRUE, 2, 500, 500),
+    ('monthly_small',            'monthly',       900,   375,   30,     TRUE, 1, 100),
+    ('monthly_middle',           'monthly',       1200,  495,  30,     TRUE, 1, 300),
+    ('monthly_large',            'monthly',       5300,  2200,  30,     TRUE, 2, 1000),
 
     ('models_small_pack',        'models',        900,   375,   NULL,   TRUE, 1, 0, 0),
     ('models_midlle_pack',       'models',        1600,  666,  NULL,   TRUE, 2, 0, 0),
     ('models_large_pack',        'models',        3600,  1500,  NULL,   TRUE, 5, 0, 0),
 
-    ('generations_bomz_pack',    'generations',   400,   165,   NULL,   TRUE, 0, 50,   50),
-    ('generations_small_pack',   'generations',   1000,  415,   NULL,   TRUE, 0, 150,  150),
-    ('generations_middle_pack',  'generations',   1800,  750,  NULL,   TRUE, 0, 300,  300),
-    ('generations_large_pack',   'generations',   5500,  2290,  NULL,   TRUE, 0, 1000, 1000);
+    ('generations_bomz_pack',    'generations',   400,   165,   NULL,   TRUE, 0, 100),
+    ('generations_small_pack',   'generations',   1000,  415,   NULL,   TRUE, 0, 300),
+    ('generations_middle_pack',  'generations',   1800,  750,  NULL,   TRUE, 0, 600),
+    ('generations_large_pack',   'generations',   5500,  2290,  NULL,   TRUE, 0, 2000);
 
 

--- a/src/model/router.py
+++ b/src/model/router.py
@@ -54,8 +54,7 @@ class OperationLimitErrorWithPending(BaseModel):
 
     code: str
     message: str
-    image_limit: int
-    promt_limit: int
+    generations_limit: int
     next_sub: str
     operation: str
 
@@ -86,8 +85,7 @@ async def generate_image_by_promnt(model_name: str, authorization: str = Header(
         err = OperationLimitErrorWithPending(
             operation=e.operation.value,
             message=e.detail,
-            image_limit=e.current_limit_image,
-            promt_limit=e.current_limit_promt,
+            generations_limit=e.current_limit,
             next_sub=datetime_to_gmt_str(e.next_sub),
             code='operation_out_limit_with_pending',
         )
@@ -110,8 +108,7 @@ async def generate_image_by_image(model_name: str, authorization: str = Header(N
         err = OperationLimitErrorWithPending(
             operation=e.operation.value,
             message=e.detail,
-            image_limit=e.current_limit_image,
-            promt_limit=e.current_limit_promt,
+            generations_limit=e.current_limit,
             next_sub=datetime_to_gmt_str(e.next_sub),
             code='operation_out_limit_with_pending',
         )

--- a/src/subscription_details/model.py
+++ b/src/subscription_details/model.py
@@ -20,8 +20,7 @@ class Subscription(BaseModel):
     start_date: datetime.datetime
     end_date: datetime.datetime | None
     models_count: int
-    photos_by_prompt_count: int
-    photos_by_image_count: int
+    generation_photos_count: int
 
     def is_monthly_sub(self) -> bool:
         return self.subscription_type == SubscriptionType.MONTHLY.value
@@ -38,6 +37,5 @@ class Subscription(BaseModel):
             start_date=row['start_date'],
             end_date=row['end_date'],
             models_count=row['models_count'],
-            photos_by_prompt_count=row['photos_by_prompt_count'],
-            photos_by_image_count=row['photos_by_image_count'],
+            generation_photos_count=row['generation_photos_count'],
         )

--- a/src/subscription_details/repository.py
+++ b/src/subscription_details/repository.py
@@ -8,7 +8,7 @@ class SubscriptionRepository:
         query = """
             SELECT id, subscription_name, subscription_type, cost_rubles, cost_stars,
                 duration, start_date, end_date,
-                models_count, photos_by_prompt_count, photos_by_image_count
+                models_count, generation_photos_count
             FROM subscriptions_details
             WHERE is_active = TRUE;
         """
@@ -16,11 +16,11 @@ class SubscriptionRepository:
         return [model.Subscription.from_row(row) for row in rows]
 
     @staticmethod
-    async def get_subscription(subscription_id: int) -> model.Subscription:
+    async def get_subscription(subscription_id: int) -> model.Subscription | None:
         query = """
             SELECT id, subscription_name, subscription_type, cost_rubles, cost_stars,
                 duration, start_date, end_date,
-                models_count, photos_by_prompt_count, photos_by_image_count
+                models_count, generation_photos_count
             FROM subscriptions_details
             WHERE id = $1;
         """

--- a/src/user/exception.py
+++ b/src/user/exception.py
@@ -30,13 +30,11 @@ class OperationOutOfLimitWithPending(HTTPException):
     def __init__(
         self,
         operation: OperationType,
-        current_limit_image: int,
-        current_limit_promt: int,
+        current_limit: int,
         next_sub: datetime,
     ):
         self.operation = operation
-        self.current_limit_image = current_limit_image
-        self.current_limit_promt = current_limit_promt
+        self.current_limit = current_limit
         self.next_sub = next_sub
 
         detail = f"Operation '{operation.value}' is out of limit."

--- a/src/user/model.py
+++ b/src/user/model.py
@@ -53,8 +53,11 @@ class UserSubscription(BaseModel):
     end_date: datetime.datetime
     status: SubcriptionStatus
 
-    photos_by_prompt_left: int
-    photos_by_image_left: int
+    generation_photos_left: int
+
+    def is_generations_left(self) -> bool:
+        return self.generation_photos_left <= 0
+
 
 
 # TODO: проверить что и в старах и в рублях проходит через эту схему

--- a/src/user/repository.py
+++ b/src/user/repository.py
@@ -119,6 +119,15 @@ class UserRepository:
         await DatabaseManager.execute(query, models_count, user_id)
 
     @staticmethod
+    async def set_user_models_limit(user_id: str, models_count: int) -> None:
+        query = """
+            UPDATE users
+            SET models_max = $1
+            WHERE user_id = $2;
+        """
+        await DatabaseManager.execute(query, models_count, user_id)
+
+    @staticmethod
     @staticmethod
     async def get_user_subscription(
         user_id: str, status: model.SubcriptionStatus

--- a/src/user/repository.py
+++ b/src/user/repository.py
@@ -153,7 +153,7 @@ class UserRepository:
 
     @staticmethod
     async def update_user_subscription_status(
-            user_sub: model.UserSubscription, status: model.SubcriptionStatus
+            user_sub: model.UserSubscription
     ) -> None:
         # Update subscription details
         update_subscription_query = """

--- a/src/user/repository.py
+++ b/src/user/repository.py
@@ -80,36 +80,6 @@ class UserRepository:
         return True
 
     @staticmethod
-    async def save_user_subscription(user_subscription: model.UserSubscription) -> None:
-        # Step 2: Insert the new subscription as active
-        insert_query = """
-            INSERT INTO user_subscriptions (user_id, subscription_id, start_date, end_date, status,
-                                            generation_photos_left)
-            VALUES ($1, $2, $3, $4, $5, $6);
-        """
-
-        await DatabaseManager.execute(
-            insert_query,
-            user_subscription.user_id,
-            user_subscription.subscription_id,
-            user_subscription.start_date,
-            user_subscription.end_date,
-            user_subscription.status.value,
-            user_subscription.generation_photos_left,
-        )
-
-    @staticmethod
-    async def add_generations_to_active_subscription(
-        user_id: str, photos: int
-    ) -> None:
-        query = """
-            UPDATE user_subscriptions
-            SET generation_photos_left = generation_photos_left + $1,
-            WHERE user_id = $2 AND status = 'active';
-        """
-        await DatabaseManager.execute(query, photos, user_id)
-
-    @staticmethod
     async def increase_user_models_limit(user_id: str, models_count: int) -> None:
         query = """
             UPDATE users
@@ -127,7 +97,6 @@ class UserRepository:
         """
         await DatabaseManager.execute(query, models_count, user_id)
 
-    @staticmethod
     @staticmethod
     async def get_user_subscription(
         user_id: str, status: model.SubcriptionStatus
@@ -181,6 +150,55 @@ class UserRepository:
             user_subscription.generation_photos_left,
             user_subscription.user_id,
         )
+
+    @staticmethod
+    async def update_user_subscription_status(
+            user_sub: model.UserSubscription, status: model.SubcriptionStatus
+    ) -> None:
+        # Update subscription details
+        update_subscription_query = """
+            UPDATE user_subscriptions
+            SET status = $1
+            WHERE id = $2;
+        """
+        await DatabaseManager.execute(
+            update_subscription_query,
+            user_sub.status,
+            user_sub.id,
+        )
+
+    @staticmethod
+    async def save_user_subscription(user_subscription: model.UserSubscription) -> None:
+        # Step 2: Insert the new subscription as active
+        insert_query = """
+            INSERT INTO user_subscriptions (user_id, subscription_id, start_date, end_date, status,
+                                            generation_photos_left)
+            VALUES ($1, $2, $3, $4, $5, $6);
+        """
+
+        await DatabaseManager.execute(
+            insert_query,
+            user_subscription.user_id,
+            user_subscription.subscription_id,
+            user_subscription.start_date,
+            user_subscription.end_date,
+            user_subscription.status.value,
+            user_subscription.generation_photos_left,
+        )
+
+    @staticmethod
+    async def add_generations_to_active_subscription(
+        user_id: str, photos: int
+    ) -> None:
+        query = """
+            UPDATE user_subscriptions
+            SET generation_photos_left = generation_photos_left + $1,
+            WHERE user_id = $2 AND status = 'active';
+        """
+        await DatabaseManager.execute(query, photos, user_id)
+
+
+
 
 
 class PaymentRepository:

--- a/src/user/router.py
+++ b/src/user/router.py
@@ -51,14 +51,14 @@ async def delete_user_from_whitelist(username: str) -> OKResponse:
 
 
 class SubcribeRequest(BaseModel):
-    subcription_id: int
+    subscription_id: int
 
 
 @user_router.post('/{user_id}/subcribe')
 async def user_buy_subscription(user_id: str, req: SubcribeRequest) -> OKResponse:
     await service.subscribe_user(
         user_id=user_id,
-        subscription_id=req.subcription_id,
+        subscription_id=req.subscription_id,
     )
 
     return OKResponse(status=True)

--- a/src/user/router.py
+++ b/src/user/router.py
@@ -54,7 +54,7 @@ class SubcribeRequest(BaseModel):
     subscription_id: int
 
 
-@user_router.post('/{user_id}/subcribe')
+@user_router.post('/{user_id}/subscribe')
 async def user_buy_subscription(user_id: str, req: SubcribeRequest) -> OKResponse:
     await service.subscribe_user(
         user_id=user_id,

--- a/src/user/service.py
+++ b/src/user/service.py
@@ -76,7 +76,7 @@ async def finish_active_sub(user_id: str) -> None:
 
     active_sub.status = model.SubcriptionStatus.FINISHED
 
-    await user_repository.update_user_subscription(active_sub)
+    await user_repository.update_user_subscription_status(active_sub)
 
 
 async def delete_user_from_whitelist(username: str) -> None:

--- a/src/user/service.py
+++ b/src/user/service.py
@@ -48,7 +48,10 @@ async def add_user_to_whitelist(username: str) -> str:
 
 
 async def activate_whitelist_subscription(user_id: str) -> None:
-    await finish_active_sub(user_id)
+    try:
+        await finish_active_sub(user_id)
+    except exception.NoActiveSubscription:
+        pass
 
     WHITELIST_GENERATION_COUNT = 1000000
     WHITELIST_MODELS_COUNT = 2
@@ -63,7 +66,7 @@ async def activate_whitelist_subscription(user_id: str) -> None:
     )
 
     await user_repository.save_user_subscription(new_user_subscription)
-    await user_repository.set_user_models_limit(user_id, WHITELIST_MODELS_COUNT)
+    await user_repository.increase_user_models_limit(user_id, WHITELIST_MODELS_COUNT)
 
 
 async def finish_active_sub(user_id: str) -> None:
@@ -73,7 +76,7 @@ async def finish_active_sub(user_id: str) -> None:
 
     active_sub.status = model.SubcriptionStatus.FINISHED
 
-    await user_repository.save_user_subscription(active_sub)
+    await user_repository.update_user_subscription(active_sub)
 
 
 async def delete_user_from_whitelist(username: str) -> None:


### PR DESCRIPTION
Изменение в API
1. subscription_details - теперь возвращается одно поле вместо двух, нужно поменять логику в боте
2. На проверку, думаю ничего менять не надо, мы же там делали запрос просто на генерацию, ты же руками не проверял лимиты.
3. поменялся запрос на generate_model - исправил опечатку - + subscription_id: int
4. Изменилось исключение, когда у юзера есть pending подписка 
            - image_limit=e.current_limit_image,
            - promt_limit=e.current_limit_promt,
            + generations_limit=e.current_limit,